### PR TITLE
Add Code Format Check CI (yapf + ruff)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,32 @@
+name: Code Format Check
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: 'pip'
+
+    - name: Install formatters
+      run: |
+        pip install --upgrade pip
+        pip install 'yapf==0.40.2' 'ruff>=0.6.0'
+
+    - name: Run format.sh
+      run: |
+        bash ./format.sh

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Usage:
+#    bash ./format.sh              # Check/format files changed vs origin/main
+#    bash ./format.sh --all        # Format the entire codebase
+#
+# This script formats all Python files that differ from origin/main.
+# You are encouraged to run this locally before pushing changes for review.
+
+set -eo pipefail
+
+# Install yapf/ruff if not available
+if ! (yapf --version &>/dev/null && ruff --version &>/dev/null); then
+    pip install --upgrade pip
+    pip install 'yapf==0.40.2' 'ruff>=0.6.0'
+fi
+
+YAPF_VERSION=$(yapf --version | awk '{print $2}')
+RUFF_VERSION=$(ruff --version | awk '{print $2}')
+
+echo "yapf: ${YAPF_VERSION}"
+echo "ruff: ${RUFF_VERSION}"
+
+# ----------------------------------------------------------------------
+# YAPF — Python formatter
+# ----------------------------------------------------------------------
+echo 'yapf: Check Start'
+
+YAPF_FLAGS=(
+    '--recursive'
+    '--parallel'
+)
+
+format_all() {
+    yapf --in-place "${YAPF_FLAGS[@]}" .
+}
+
+format_changed() {
+    if git show-ref --verify --quiet refs/remotes/origin/main; then
+        BASE_BRANCH="origin/main"
+    else
+        BASE_BRANCH="main"
+    fi
+
+    MERGEBASE="$(git merge-base $BASE_BRANCH HEAD)"
+
+    if ! git diff --diff-filter=ACM --quiet --exit-code "$MERGEBASE" -- '*.py' '*.pyi' &>/dev/null; then
+        git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.py' '*.pyi' | xargs -P 5 \
+             yapf --in-place "${YAPF_FLAGS[@]}"
+    fi
+}
+
+if [[ "$1" == '--all' ]]; then
+    format_all
+else
+    format_changed
+fi
+echo 'yapf: Done'
+
+# ----------------------------------------------------------------------
+# Ruff — Python linter
+# ----------------------------------------------------------------------
+echo 'ruff: Check Start'
+
+lint_all() {
+    ruff check .
+}
+
+lint_changed() {
+    if git show-ref --verify --quiet refs/remotes/origin/main; then
+        BASE_BRANCH="origin/main"
+    else
+        BASE_BRANCH="main"
+    fi
+
+    MERGEBASE="$(git merge-base $BASE_BRANCH HEAD)"
+
+    if ! git diff --diff-filter=ACM --quiet --exit-code "$MERGEBASE" -- '*.py' '*.pyi' &>/dev/null; then
+        git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.py' '*.pyi' | xargs -P 5 \
+             ruff check
+    fi
+}
+
+if [[ "$1" == '--all' ]]; then
+    lint_all
+else
+    lint_changed
+fi
+echo 'ruff: Done'
+
+# ----------------------------------------------------------------------
+# Check for uncommitted changes
+# ----------------------------------------------------------------------
+if ! git diff --quiet &>/dev/null; then
+    echo ''
+    echo 'Reformatted files. Please review and stage the changes.'
+    echo ''
+    echo 'Changed files:'
+    git --no-pager diff --name-only
+
+    echo ''
+    echo 'You can also review the full diff below:'
+    echo ''
+    git --no-pager diff
+
+    exit 1
+fi
+
+echo ''
+echo 'All checks passed.'


### PR DESCRIPTION
## Summary

Add GitHub Actions CI for code format checking (yapf + ruff) and a local `format.sh` script, following the conventions already used in `deepseek-ai/DeepEP`.

### Changes

- **`.github/workflows/format.yml`**: GitHub Actions workflow that runs `format.sh` on every push to `main` and on every pull request.
- **`format.sh`**: Local formatting script that:
  - Runs `yapf` to format Python files
  - Runs `ruff` to lint Python files
  - Checks only files changed vs `origin/main` (or all files with `--all`)
  - Exits with code 1 if any files need reformatting

### Design Decisions

- **Python-only**: TileKernels contains only `.py` files, so clang-format is not included (unlike DeepEP which has C/CUDA).
- **Ruff version**: Pinned to `>=0.6.0` (TileKernels pyproject.toml already has a ruff config).
- **YAPF version**: Pinned to `0.40.2` to match DeepEP.
- **CI cache**: Uses `actions/setup-python` built-in pip cache to speed up installs.

### Testing

The script was tested locally:
1. **Clean state**: `bash format.sh` exits 0 when no files need reformatting ✅
2. **New bad formatting**: Introducing badly-formatted new code causes the script to exit 1 and list the affected files ✅
3. **No forced reformatting**: Existing codebase files are not reformatted by this PR (format-on-push only happens after merge)