### PR TITLE
fix(mhc): MHCPreNormFn.backward returns wrong number of gradients

### DIFF
--- a/tile_kernels/modeling/mhc/ops/norm_fn.py
+++ b/tile_kernels/modeling/mhc/ops/norm_fn.py
@@ -129,7 +129,7 @@ class MHCPreNormFn(torch.autograd.Function):
     def backward(
         ctx: 'MHCPreNormFn',
         out_grad: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None]:
+    ) -> tuple[torch.Tensor | None, torch.Tensor, None, None, None]:
         x, fn, out_mul, sqrsum = ctx.saved_tensors
         norm_eps = ctx.norm_eps
 
@@ -166,8 +166,8 @@ class MHCPreNormFn(torch.autograd.Function):
 
         if ctx.fuse_grad_acc:
             del x.untyped_storage().grad_from_mhc_post
-            return None, fn_grad, None, None, None, None
-        return x_grad, fn_grad, None, None, None, None
+            return None, fn_grad, None, None, None
+        return x_grad, fn_grad, None, None, None
 
 
 def mhc_pre_norm_fn(


### PR DESCRIPTION
## Summary

`MHCPreNormFn.forward` (`tile_kernels/modeling/mhc/ops/norm_fn.py`) takes **5** user inputs (`x`, `fn`, `norm_eps`, `fuse_grad_acc`, `n_splits`), but `backward` returns **6** elements. PyTorch autograd requires one returned gradient per input, so this raises at runtime:

```
RuntimeError: function MHCPreNormFnBackward returned an incorrect number of gradients (expected 5, got 6)
```

## Fix

Drop the trailing `None` from both return statements so the arity matches the 5 forward inputs, and update the type annotation to reflect the real return shape (`x_grad` is `None` when `fuse_grad_acc=True`).

```diff
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, None, None]:
+    ) -> tuple[torch.Tensor | None, torch.Tensor, None, None, None]:
...
-            return None, fn_grad, None, None, None, None
-        return x_grad, fn_grad, None, None, None, None
+            return None, fn_grad, None, None, None
+        return x_grad, fn_grad, None, None, None
```
