### PR TITLE
fix(tests/pytest_random_plugin.py): also seed Python's `random`

### DIFF
--- a/tests/pytest_random_plugin.py
+++ b/tests/pytest_random_plugin.py
@@ -1,4 +1,5 @@
 import hashlib
+import random
 
 import pytest
 import torch
@@ -15,4 +16,5 @@ def seed(request):
     ).hexdigest(), 16) % (2**31)
     seed = base + node_hash
     torch.manual_seed(seed)
+    random.seed(seed)
     return seed


### PR DESCRIPTION
Closes #11.

## What

Add `random.seed(seed)` next to `torch.manual_seed(seed)` in the autouse
`seed` fixture so the `--seed` CLI option reproduces test inputs that
flow through Python's stdlib `random`.

## Why

`tile_kernels/testing/generator.py:94` (`generate_rand_float`) picks the
magnitude exponent with `random.randint(-110, 126)`. The plugin only
seeds torch, so this exponent — and therefore the input scale used by
tests like `tests/quant/test_per_block_cast_lossless.py` — varies
across runs even when `--seed` is passed.

## Reproduction

The bug is in a pure-Python entropy source, so it reproduces without a
GPU. Mirroring the fixture and `generator.py:94`:

```
run 1 exponents: [97, -60, 98, -69, 102, -84, 119, 2]
run 2 exponents: [80, -68, -47, 94,   0,  33, -74, 77]
run 3 exponents: [-69, -29, -106, 39, 87, 97, 19, 92]
```

Three back-to-back invocations with the same simulated `--seed=0` and
the same node id produce three different sequences. With the patch,
both invocations within one process produce identical sequences.

## Scope

- One import + one line. No behavior change for tests that don't touch
  Python's `random`.
- Does not touch NumPy — `grep -r 'np\.random\|numpy.*random'` is
  empty in this repo.