### PR TITLE
[BugFix][Quant] Guard scale tails and FP32 absmax

### DIFF
--- a/tile_kernels/quant/cast_back_kernel.py
+++ b/tile_kernels/quant/cast_back_kernel.py
@@ -60,11 +60,16 @@ def get_cast_back_kernel(
             out_fragment = T.alloc_fragment((TILE_M, TILE_K), out_dtype)
 
             T.copy(x[pid_token * TILE_M, pid_hidden * TILE_K], x_shared, disable_tma=True)
+            num_sf_token_blocks = T.ceildiv(num_tokens, num_per_tokens)
+            num_sf_channel_blocks = T.ceildiv(hidden, num_per_channels)
             for i, j in T.Parallel(T.ceildiv(TILE_M, num_per_tokens), T.ceildiv(TILE_K, num_per_channels)):
                 token_index = pid_token * TILE_M // num_per_tokens + i
                 channel_index = pid_hidden * TILE_K // num_per_channels + j
-                sf = load_sf(x_sf, token_index, channel_index, in_config)
-                sf_shared[i, j] = transform_sf(sf, in_config)
+                if token_index < num_sf_token_blocks and channel_index < num_sf_channel_blocks:
+                    sf = load_sf(x_sf, token_index, channel_index, in_config)
+                    sf_shared[i, j] = transform_sf(sf, in_config)
+                else:
+                    sf_shared[i, j] = 0
 
             for i, j in T.Parallel(TILE_M, TILE_K):
                 out_fragment[i, j] = x_shared[i, j] * sf_shared[i // num_per_tokens, j // num_per_channels]

--- a/tile_kernels/quant/per_block_cast_lossless_kernel.py
+++ b/tile_kernels/quant/per_block_cast_lossless_kernel.py
@@ -88,10 +88,13 @@ def get_per_block_cast_lossless_kernel(
 
             # Load scaling factor of x to fragment
             T.fill(x_sf_fragment, 0)
+            num_in_sf_blocks_m = T.ceildiv(num_tokens, in_config.sf_block[0])
+            num_in_sf_blocks_k = T.ceildiv(hidden, in_config.sf_block[1])
             for i, j in T.Parallel(num_in_sf_per_block_m, num_in_sf_per_block_k):
                 m_idx = pid_token * block_m // in_config.sf_block[0] + i
                 k_idx = pid_hidden * block_k // in_config.sf_block[1] + j
-                x_sf_fragment[i, j] = load_sf(x_sf, m_idx, k_idx, in_config)
+                if m_idx < num_in_sf_blocks_m and k_idx < num_in_sf_blocks_k:
+                    x_sf_fragment[i, j] = load_sf(x_sf, m_idx, k_idx, in_config)
 
             # Alloc fragments
             x_sf_uint32_fragment = T.alloc_fragment((num_in_sf_per_block_m, num_in_sf_per_block_k), T.uint32)
@@ -137,14 +140,17 @@ def get_per_block_cast_lossless_kernel(
                 x_out_fragment[i, j] = T.cast(T.float32(x_in_shared[i, j]) * sf, out_config.dtype)
 
             # Store scaling factor back to global memory
+            num_out_sf_blocks_m = T.ceildiv(num_tokens, out_config.sf_block[0])
+            num_out_sf_blocks_k = T.ceildiv(hidden, out_config.sf_block[1])
             for i, j in T.Parallel(num_out_sf_per_block_m, num_out_sf_per_block_k):
                 sf_m_idx = pid_token * num_out_sf_per_block_m + i
                 sf_k_idx = pid_hidden * num_out_sf_per_block_k + j
-                if out_config.use_packed_ue8m0:
-                    sf = T.uint8(out_sf_uint32_fragment[i, j])
-                else:
-                    sf = transform_sf_to_fp32(out_sf_uint32_fragment[i, j])
-                store_sf(out_sf, sf, sf_m_idx, sf_k_idx, out_config)
+                if sf_m_idx < num_out_sf_blocks_m and sf_k_idx < num_out_sf_blocks_k:
+                    if out_config.use_packed_ue8m0:
+                        sf = T.uint8(out_sf_uint32_fragment[i, j])
+                    else:
+                        sf = transform_sf_to_fp32(out_sf_uint32_fragment[i, j])
+                    store_sf(out_sf, sf, sf_m_idx, sf_k_idx, out_config)
 
             T.copy(x_out_fragment, out[pid_token * block_m: (pid_token + 1) * block_m, pid_hidden * block_k: (pid_hidden + 1) * block_k])
 

--- a/tile_kernels/quant/per_token_cast_kernel.py
+++ b/tile_kernels/quant/per_token_cast_kernel.py
@@ -115,7 +115,8 @@ def get_per_token_cast_kernel(
                     # Store SF
                     m_idx = pid_token * block_m + i
                     k_idx = pid_hidden * num_groups + j
-                    store_sf(out_sf, sf, m_idx, k_idx, out_config)
+                    if m_idx < num_tokens:
+                        store_sf(out_sf, sf, m_idx, k_idx, out_config)
                     sf_inv_fragment[i, j] = sf_inv
 
                 # Store casted values
@@ -131,7 +132,7 @@ def get_per_token_cast_kernel(
                         sf = load_sf(out_sf, pid_token * block_m + i, pid_hidden * num_groups + j, out_config)
                         sf_inv_fragment[i, j] = 1 / sf
                 else:
-                    amax_fragment = T.alloc_fragment((block_m, num_groups), in_config.dtype)
+                    amax_fragment = T.alloc_fragment((block_m, num_groups), T.float32)
                     x_fragment_reshaped = T.reshape(x_fragment, [block_m, num_groups, num_per_channels])
                     # Reduce SF
                     T.reduce_absmax(x_fragment_reshaped, amax_fragment, dim=2)
@@ -142,7 +143,8 @@ def get_per_token_cast_kernel(
                         # Store SF
                         m_idx = pid_token * block_m + i
                         k_idx = pid_hidden * num_groups + j
-                        store_sf(out_sf, sf, m_idx, k_idx, out_config)
+                        if m_idx < num_tokens:
+                            store_sf(out_sf, sf, m_idx, k_idx, out_config)
                         sf_inv_fragment[i, j] = sf_inv
 
                 # Store casted values

--- a/tile_kernels/quant/per_token_cast_to_e5m6_kernel.py
+++ b/tile_kernels/quant/per_token_cast_to_e5m6_kernel.py
@@ -119,7 +119,7 @@ def get_per_token_cast_to_e5m6_kernel(
             # Copy input into registers
             T.copy(x[pid_token * block_m, pid_hidden * block_k], x_fragment)
 
-            amax_fragment = T.alloc_fragment((block_m, num_groups), in_config.dtype)
+            amax_fragment = T.alloc_fragment((block_m, num_groups), T.float32)
             x_fragment_reshaped = T.reshape(x_fragment, [block_m, num_groups, num_per_channels])
             # Reduce SF
             T.reduce_absmax(x_fragment_reshaped, amax_fragment, dim=2)
@@ -130,7 +130,8 @@ def get_per_token_cast_to_e5m6_kernel(
                 # Store SF
                 m_idx = pid_token * block_m + i
                 k_idx = pid_hidden * num_groups + j
-                store_sf(out_sf, sf, m_idx, k_idx, out_config)
+                if m_idx < num_tokens:
+                    store_sf(out_sf, sf, m_idx, k_idx, out_config)
                 sf_inv_fragment[i, j] = sf_inv
 
             T.annotate_layout({
@@ -150,8 +151,11 @@ def get_per_token_cast_to_e5m6_kernel(
                 for j in T.serial(8):
                     in_local[j] = out_fragment[x, y * 8 + j]
                 float_to_e5m6(in_local, out_local)
-                for j in T.serial(3):
-                    out[pid_token * block_m + x, pid_hidden * (block_k // 8 * 3) + y * 3 + j] = out_local[j]
+                m_idx = pid_token * block_m + x
+                k_idx = pid_hidden * block_k + y * 8
+                if m_idx < num_tokens and k_idx < hidden:
+                    for j in T.serial(3):
+                        out[m_idx, (k_idx // 8) * 3 + j] = out_local[j]
 
     return per_token_cast_to_e5m6_kernel
 


### PR DESCRIPTION
## Context

This updates the existing Quant PR to cover the complete Quant-side fix from the H100 CuTeDSL full correctness and benchmark run.

The earlier version of this PR only handled the BF16 per-token FP32 amax issue. Full coverage also exposed tail-tile scale-grid and packed E5M6 store bounds issues, so this PR now keeps the Quant fixes together in one review instead of opening duplicate overlapping PRs.

## Problems Found

Full H100/CuTeDSL coverage exercises quantization shapes where token counts, hidden sizes, scale blocks, and packed E5M6 groups do not always land exactly on a kernel tile boundary.

That exposed two TileKernels-side issues:

- Tail tiles could load or store scaling factors outside the real scaling-factor grid.
- Per-token scale generation used `in_config.dtype` as the absmax fragment dtype, even though that dtype describes input storage rather than the reduction accumulator.

For BF16 and narrow quantization paths, using the input storage dtype as the absmax accumulator can round or overflow the scale path before the final cast, producing byte mismatches against the PyTorch reference.

## Fix

- Guard scale loads in cast-back and per-block lossless paths with the real scale-grid dimensions.
- Guard scale stores in per-block and per-token cast paths with the real token/channel scale extents.
- Guard packed E5M6 output stores for token and hidden tail tiles.
- Use `T.float32` fragments for per-token absmax reductions before computing reciprocal scales.

## Why this belongs in TileKernels

These are kernel-level bounds and accumulator-dtype issues. The implementation schedules aligned tile work for performance, but memory accesses and reduction precision must still follow the logical tensor/scaling-factor layout. The fix is not tied to one CuTeDSL package version.

## Relationship to Existing PRs

- This PR supersedes #16 because it includes the E5M6 FP32 amax fix and the E5M6 tail-store guard.
- No separate Quant duplicate PR is needed.

## Validation

Validated as part of the H100 PCIe CuTeDSL full correctness and benchmark run after the matching TileLang CuTeDSL fixes were applied.

Local sanity checks for the current branch:

- `git diff --check origin/main..82fbd40`
- `ruff check` on the changed TileKernels Python files

JayceSu98 <jayce.su@enflame-tech.com> authored and validated this patch.

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>